### PR TITLE
✨ 가족 생성 API 기능 분리

### DIFF
--- a/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
+++ b/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
@@ -1,10 +1,13 @@
 package com.nuzzle.backend.family.controller;
 
 import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.dto.FamilyDTO;
 import com.nuzzle.backend.family.service.FamilyService;
 import com.nuzzle.backend.user.domain.User;
 import com.nuzzle.backend.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -21,21 +24,25 @@ public class FamilyController {
     private UserService user_service;
 
     @PostMapping("/create")
-    public Map<String, Object> createFamily(@RequestParam Long user_id) {
+    public ResponseEntity<Map<String, Object>> createFamily(@RequestBody FamilyDTO.CreateFamilyRequest request) {
         // 유저 정보 가져오기
-        User user = user_service.getUserById(user_id);
-        // 가족 생성
-        Family family = family_service.createFamily(user);
+        User user = user_service.getUserById(request.getUserId());
 
         // 응답 데이터 생성
         Map<String, Object> response = new HashMap<>();
-        response.put("family_id", family.getFamilyId());
-        response.put("pet_name", family.getPetName()); // pet_name은 null일 수 있음
-        response.put("pet_color", family.getPetColor()); // pet_color는 null일 수 있음
-        response.put("invitation_code", family.getInvitationCode());
-        response.put("family_status", family.getFamilyStatus());
-
-        return response;
+        try {
+            // 가족 생성
+            FamilyDTO family = family_service.createFamily(user);
+            response.put("family_id", family.getFamilyId());
+            response.put("pet_name", family.getPetName()); // pet_name은 null일 수 있음
+            response.put("pet_color", family.getPetColor()); // pet_color는 null일 수 있음
+            response.put("invitation_code", family.getInvitationCode());
+            response.put("family_status", family.getFamilyStatus());
+            return ResponseEntity.ok(response);
+        } catch (IllegalStateException e) {
+            response.put("message", e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+        }
     }
 
     @PostMapping("/join")

--- a/src/main/java/com/nuzzle/backend/family/domain/Family.java
+++ b/src/main/java/com/nuzzle/backend/family/domain/Family.java
@@ -3,6 +3,7 @@ package com.nuzzle.backend.family.domain;
 import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
 import com.nuzzle.backend.family.domain.mapping.FamilyQuestion;
 import com.nuzzle.backend.pet.domain.Pet;
+import com.nuzzle.backend.pet.domain.PetColor;
 import com.nuzzle.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -19,8 +20,9 @@ public class Family {
     @Column(name = "pet_name")
     private String petName;
 
+    @Enumerated(EnumType.STRING) // EnumType.STRING으로 지정
     @Column(name = "pet_color")
-    private String petColor;
+    private PetColor petColor;
 
     @Column(name = "family_status")
     private String familyStatus;

--- a/src/main/java/com/nuzzle/backend/family/dto/FamilyDTO.java
+++ b/src/main/java/com/nuzzle/backend/family/dto/FamilyDTO.java
@@ -1,0 +1,36 @@
+package com.nuzzle.backend.family.dto;
+
+import com.nuzzle.backend.pet.domain.PetColor;
+import com.nuzzle.backend.pet.dto.PetDTO;
+import com.nuzzle.backend.user.dto.UserDTO;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FamilyDTO {
+    private Long familyId;
+    private String petName;
+    private PetColor petColor;
+    private String familyStatus;
+    private String invitationCode;
+    private PetDTO pet;
+    private List<UserDTO> users;
+
+    // CreateFamilyRequest와 JoinFamilyRequest를 포함한 내부 클래스를 추가
+    @Data
+    public static class CreateFamilyRequest {
+        private Long userId;
+    }
+
+    @Data
+    public static class JoinFamilyRequest {
+        private Long userId;
+        private String invitationCode;
+    }
+
+    @Data
+    public static class LeaveFamilyRequest {
+        private Long userId;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/family/service/FamilyService.java
+++ b/src/main/java/com/nuzzle/backend/family/service/FamilyService.java
@@ -1,12 +1,13 @@
 package com.nuzzle.backend.family.service;
 
 import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.dto.FamilyDTO;
 import com.nuzzle.backend.user.domain.User;
 
 import java.util.List;
 
 public interface FamilyService {
-    Family createFamily(User user); // 가족 생성 메서드
+    FamilyDTO createFamily(User user); // 가족 생성 메서드
     Family joinFamily(User user, String invitationCode); // 초대 코드로 가족에 합류하는 메서드
     void leaveFamily(User user); // 가족을 탈퇴하는 메서드
     Family getFamily(Long familyId); // 가족 정보를 가져오는 메서드

--- a/src/main/java/com/nuzzle/backend/pet/domain/PetColor.java
+++ b/src/main/java/com/nuzzle/backend/pet/domain/PetColor.java
@@ -1,0 +1,9 @@
+package com.nuzzle.backend.pet.domain;
+
+public enum PetColor {
+    BLACK,
+    BROWN,
+    WHITE,
+    GOLDEN,
+    GRAY
+}

--- a/src/main/java/com/nuzzle/backend/pet/dto/PetDTO.java
+++ b/src/main/java/com/nuzzle/backend/pet/dto/PetDTO.java
@@ -1,0 +1,10 @@
+package com.nuzzle.backend.pet.dto;
+
+import lombok.Data;
+
+@Data
+public class PetDTO {
+    private Long petId;
+    private String petType;
+    private String petImg;
+}

--- a/src/main/java/com/nuzzle/backend/user/dto/UserDTO.java
+++ b/src/main/java/com/nuzzle/backend/user/dto/UserDTO.java
@@ -1,0 +1,16 @@
+package com.nuzzle.backend.user.dto;
+
+import com.nuzzle.backend.family.dto.FamilyDTO;
+import lombok.Data;
+
+@Data
+public class UserDTO {
+    private Long userId;
+    private String userName;
+    private String gender;
+    private String serialId;
+    private String password;
+    private String role;
+    private String birthDate;
+    private FamilyDTO family;
+}


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [레포 이름 #3](이슈 주소)
- [nuzzle-backend #3 ](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/3)
- Closes #3 
<br/>

## 📝 작업 내용

- PetColor를 Enum으로 설정하였습니다.
- 가족 생성 API를 구현했습니다.
- 해당 기능을 통해 새로운 가족을 생성하고, 생성된 가족의 ID와 초대 코드를 반환합니다.
- User가 이미 가족에 소속되어 있는 경우 예외를 처리했습니다.


<br/>

## 🔧 앞으로의 과제

- 향후 다른 가족 관련 기능 (가족 코드로 구성원 추가, 가족 탈퇴 등)을 구현할 예정입니다.