### PR TITLE
✨가족별 초대코드 불러오는 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
+++ b/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
@@ -5,7 +5,10 @@ import com.nuzzle.backend.family.service.FamilyService;
 import com.nuzzle.backend.user.domain.User;
 import com.nuzzle.backend.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashMap;
 import java.util.List;
@@ -89,14 +92,17 @@ public class FamilyController {
     }
 
     @GetMapping("/{family_id}/invitation-code")
-    public Map<String, String> getInvitationCode(@PathVariable Long family_id) {
+    public ResponseEntity<Map<String, String>> getInvitationCode(@PathVariable Long family_id) {
         // 가족 초대 코드 가져오기
-        String invitation_code = family_service.getInvitationCode(family_id);
+        try {
+            String invitation_code = family_service.getInvitationCode(family_id);
 
-        // 응답 데이터 생성
-        Map<String, String> response = new HashMap<>();
-        response.put("invitation_code", invitation_code);
+            Map<String, String> response = new HashMap<>();
+            response.put("invitation_code", invitation_code);
 
-        return response;
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/nuzzle/backend/family/service/impl/FamilyServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/family/service/impl/FamilyServiceImpl.java
@@ -87,7 +87,7 @@ public class FamilyServiceImpl implements FamilyService {
     @Override
     public String getInvitationCode(Long familyId) {
         // 가족 ID로 초대 코드 가져오기
-        Family family = getFamily(familyId);
+        Family family = familyRepository.findById(familyId).orElseThrow(() -> new IllegalArgumentException("가족을 찾지 못했습니다."));
         return family.getInvitationCode();
     }
 }


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [nuzzle-backend #5 ](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/5)
- Closes #5 

<br/>

## 📝 작업 내용

- 가족별 초대코드를 불러오는 API를 구현했습니다.
- 사용자는 이 API를 통해 자신이 생성한 가족의 초대코드를 확인할 수 있습니다.
- 초대코드는 가족 생성 시 자동으로 생성되며, 고유한 값입니다.

<br/>

## 🔧 앞으로의 과제

- 다른 가족 구성원 추가 관련 기능을 계속해서 구현할 예정입니다.
