### PR TITLE
✨ [Feature] - 가족 탈퇴 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
+++ b/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
@@ -1,10 +1,13 @@
 package com.nuzzle.backend.family.controller;
 
 import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.dto.FamilyDTO;
 import com.nuzzle.backend.family.service.FamilyService;
 import com.nuzzle.backend.user.domain.User;
 import com.nuzzle.backend.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -57,16 +60,20 @@ public class FamilyController {
     }
 
     @PostMapping("/leave")
-    public Map<String, String> leaveFamily(@RequestParam Long user_id) {
+    public ResponseEntity<Map<String, String>> leaveFamily(@RequestBody FamilyDTO.LeaveFamilyRequest request) {
         // 유저 정보 가져오기
-        User user = user_service.getUserById(user_id);
-        // 가족 탈퇴
-        family_service.leaveFamily(user);
+        User user = user_service.getUserById(request.getUserId());
 
-        // 응답 메시지 생성
         Map<String, String> response = new HashMap<>();
-        response.put("message", "Successfully left the family.");
-        return response;
+        try {
+            // 가족 탈퇴
+            family_service.leaveFamily(user);
+            response.put("message", "성공적으로 가족을 탈퇴했습니다.");
+            return ResponseEntity.ok(response);
+        } catch (IllegalStateException e) {
+            response.put("message", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
     }
 
     @GetMapping("/{family_id}")

--- a/src/main/java/com/nuzzle/backend/family/dto/FamilyDTO.java
+++ b/src/main/java/com/nuzzle/backend/family/dto/FamilyDTO.java
@@ -1,0 +1,36 @@
+package com.nuzzle.backend.family.dto;
+
+import com.nuzzle.backend.pet.domain.PetColor;
+import com.nuzzle.backend.pet.dto.PetDTO;
+import com.nuzzle.backend.user.dto.UserDTO;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FamilyDTO {
+    private Long familyId;
+    private String petName;
+    private PetColor petColor;
+    private String familyStatus;
+    private String invitationCode;
+    private PetDTO pet;
+    private List<UserDTO> users;
+
+    // CreateFamilyRequest와 JoinFamilyRequest를 포함한 내부 클래스를 추가
+    @Data
+    public static class CreateFamilyRequest {
+        private Long userId;
+    }
+
+    @Data
+    public static class JoinFamilyRequest {
+        private Long userId;
+        private String invitationCode;
+    }
+
+    @Data
+    public static class LeaveFamilyRequest {
+        private Long userId;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/family/service/impl/FamilyServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/family/service/impl/FamilyServiceImpl.java
@@ -63,7 +63,7 @@ public class FamilyServiceImpl implements FamilyService {
     public void leaveFamily(User user) {
         // 유저가 가족에 속해 있지 않은 경우 예외 발생
         if (user.getFamily() == null) {
-            throw new IllegalStateException("User is not in a family");
+            throw new IllegalStateException("소속된 가족이 없어 탈퇴할 수 없습니다.");
         }
 
         // 유저를 가족에서 제거

--- a/src/main/java/com/nuzzle/backend/pet/domain/PetColor.java
+++ b/src/main/java/com/nuzzle/backend/pet/domain/PetColor.java
@@ -1,0 +1,9 @@
+package com.nuzzle.backend.pet.domain;
+
+public enum PetColor {
+    BLACK,
+    BROWN,
+    WHITE,
+    GOLDEN,
+    GRAY
+}

--- a/src/main/java/com/nuzzle/backend/pet/dto/PetDTO.java
+++ b/src/main/java/com/nuzzle/backend/pet/dto/PetDTO.java
@@ -1,0 +1,10 @@
+package com.nuzzle.backend.pet.dto;
+
+import lombok.Data;
+
+@Data
+public class PetDTO {
+    private Long petId;
+    private String petType;
+    private String petImg;
+}

--- a/src/main/java/com/nuzzle/backend/user/dto/UserDTO.java
+++ b/src/main/java/com/nuzzle/backend/user/dto/UserDTO.java
@@ -1,0 +1,16 @@
+package com.nuzzle.backend.user.dto;
+
+import com.nuzzle.backend.family.dto.FamilyDTO;
+import lombok.Data;
+
+@Data
+public class UserDTO {
+    private Long userId;
+    private String userName;
+    private String gender;
+    private String serialId;
+    private String password;
+    private String role;
+    private String birthDate;
+    private FamilyDTO family;
+}


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [레포 이름 #7](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/7)
- Closes #7 

<br/>

## 📝 작업 내용

- 가족 탈퇴 API를 구현했습니다.
- 사용자가 현재 속해 있는 가족에서 탈퇴할 수 있도록 기능을 추가했습니다.
- 사용자가 탈퇴할 때, 해당 사용자 정보에서 가족 ID가 제거되도록 설정했습니다.

<br/>

## 🔧 앞으로의 과제

- 가족 탈퇴 후 다른 가족에 다시 가입할 수 있는 기능을 구현할 예정입니다.
