### PR TITLE
[Feature] - 여러 키워드 삭제 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/family/controller/FamilyKeywordController.java
+++ b/src/main/java/com/nuzzle/backend/family/controller/FamilyKeywordController.java
@@ -1,0 +1,39 @@
+package com.nuzzle.backend.family.controller;
+
+import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
+import com.nuzzle.backend.family.dto.FamilyKeywordDTO;
+import com.nuzzle.backend.family.service.FamilyKeywordService;
+import com.nuzzle.backend.family.service.FamilyService;
+import com.nuzzle.backend.keyword.repository.KeywordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/family-keywords")
+public class FamilyKeywordController {
+
+    @Autowired
+    private FamilyKeywordService familyKeywordService;
+
+    @Autowired
+    private FamilyService familyService;
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+
+
+
+    // 여러 키워드를 가족에서 제거
+    @DeleteMapping("/remove-multiple")
+    public ResponseEntity<Void> removeKeywordsFromFamily(@RequestBody FamilyKeywordDTO.RemoveKeywordsRequest request) {
+        familyKeywordService.removeKeywordsFromFamily(request.getFamilyId(), request.getKeywordIds());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+
+}

--- a/src/main/java/com/nuzzle/backend/family/dto/FamilyKeywordDTO.java
+++ b/src/main/java/com/nuzzle/backend/family/dto/FamilyKeywordDTO.java
@@ -1,0 +1,25 @@
+package com.nuzzle.backend.family.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FamilyKeywordDTO {
+    private Long familyKeywordId;
+    private Long familyId;
+    private Long keywordId;
+    private String keywordName;
+
+    @Data
+    public static class AddKeywordsRequest {
+        private Long familyId;
+        private List<Long> keywordIds;
+    }
+
+    @Data
+    public static class RemoveKeywordsRequest {  // 여러 키워드 삭제 요청을 위한 클래스
+        private Long familyId;
+        private List<Long> keywordIds;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/family/repository/FamilyKeywordRepository.java
+++ b/src/main/java/com/nuzzle/backend/family/repository/FamilyKeywordRepository.java
@@ -1,7 +1,12 @@
 package com.nuzzle.backend.family.repository;
 
+import com.nuzzle.backend.family.domain.Family;
 import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FamilyKeywordRepository extends JpaRepository<FamilyKeyword, Long> {
+    List<FamilyKeyword> findByFamily(Family family);
+
 }

--- a/src/main/java/com/nuzzle/backend/family/service/FamilyKeywordService.java
+++ b/src/main/java/com/nuzzle/backend/family/service/FamilyKeywordService.java
@@ -1,0 +1,10 @@
+package com.nuzzle.backend.family.service;
+
+import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
+
+import java.util.List;
+
+public interface FamilyKeywordService {
+
+    void removeKeywordsFromFamily(Long familyId, List<Long> keywordIds);
+}

--- a/src/main/java/com/nuzzle/backend/family/service/impl/FamilyKeywordServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/family/service/impl/FamilyKeywordServiceImpl.java
@@ -1,0 +1,48 @@
+package com.nuzzle.backend.family.service.impl;
+
+import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
+import com.nuzzle.backend.family.repository.FamilyKeywordRepository;
+import com.nuzzle.backend.family.repository.FamilyRepository;
+import com.nuzzle.backend.family.service.FamilyKeywordService;
+import com.nuzzle.backend.keyword.domain.Keyword;
+import com.nuzzle.backend.keyword.repository.KeywordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FamilyKeywordServiceImpl implements FamilyKeywordService {
+
+    @Autowired
+    private FamilyKeywordRepository familyKeywordRepository;
+
+    @Autowired
+    private FamilyRepository familyRepository;
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+
+
+
+    @Override
+    @Transactional
+    public void removeKeywordsFromFamily(Long familyId, List<Long> keywordIds) {
+        Family family = familyRepository.findById(familyId)
+                .orElseThrow(() -> new IllegalArgumentException("가족을 찾을 수 없습니다."));
+
+        List<FamilyKeyword> familyKeywordsToDelete = familyKeywordRepository.findByFamily(family).stream()
+                .filter(fk -> keywordIds.contains(fk.getKeyword().getKeywordId()))
+                .collect(Collectors.toList());
+
+        if (familyKeywordsToDelete.isEmpty()) {
+            throw new IllegalArgumentException("삭제할 키워드가 없습니다.");
+        }
+
+        familyKeywordRepository.deleteAll(familyKeywordsToDelete);
+    }
+
+}


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [레포 이름 #10 ](이슈 주소)
- Closes #10

<br/>

## 📝 작업 내용

- 가족에서 여러 키워드를 한 번에 삭제할 수 있는 API를 구현했습니다.
- 삭제하려는 키워드가 가족에 존재하지 않는 경우 예외 처리를 추가했습니다.

<br/>

## 🔧 앞으로의 과제

- 키워드를 삭제할 때, 확인 메시지를 추가하는 등의 사용자 경험 개선 작업을 할 예정입니다.
