### PR TITLE
✨[Feature] - 가족의 키워드 조회 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/family/controller/FamilyKeywordController.java
+++ b/src/main/java/com/nuzzle/backend/family/controller/FamilyKeywordController.java
@@ -1,0 +1,50 @@
+package com.nuzzle.backend.family.controller;
+
+import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
+import com.nuzzle.backend.family.dto.FamilyKeywordDTO;
+import com.nuzzle.backend.family.service.FamilyKeywordService;
+import com.nuzzle.backend.family.service.FamilyService;
+import com.nuzzle.backend.keyword.repository.KeywordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/family-keywords")
+public class FamilyKeywordController {
+
+    @Autowired
+    private FamilyKeywordService familyKeywordService;
+
+    @Autowired
+    private FamilyService familyService;
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+
+
+    // 가족의 키워드 조회
+    @GetMapping("/{familyId}")
+    public ResponseEntity<List<FamilyKeywordDTO>> getKeywordsByFamily(@PathVariable Long familyId) {
+        List<FamilyKeyword> familyKeywords = familyKeywordService.getKeywordsByFamily(familyId);
+        List<FamilyKeywordDTO> response = familyKeywords.stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+    // DTO 변환 메서드
+    private FamilyKeywordDTO convertToDTO(FamilyKeyword familyKeyword) {
+        FamilyKeywordDTO dto = new FamilyKeywordDTO();
+        dto.setFamilyKeywordId(familyKeyword.getFamilyKeywordId());
+        dto.setFamilyId(familyKeyword.getFamily().getFamilyId());
+        dto.setKeywordId(familyKeyword.getKeyword().getKeywordId());
+        dto.setKeywordName(familyKeyword.getKeyword().getKeyword());
+        return dto;
+    }
+
+}

--- a/src/main/java/com/nuzzle/backend/family/dto/FamilyKeywordDTO.java
+++ b/src/main/java/com/nuzzle/backend/family/dto/FamilyKeywordDTO.java
@@ -1,0 +1,25 @@
+package com.nuzzle.backend.family.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FamilyKeywordDTO {
+    private Long familyKeywordId;
+    private Long familyId;
+    private Long keywordId;
+    private String keywordName;
+
+    @Data
+    public static class AddKeywordsRequest {
+        private Long familyId;
+        private List<Long> keywordIds;
+    }
+
+    @Data
+    public static class RemoveKeywordsRequest {  // 여러 키워드 삭제 요청을 위한 클래스
+        private Long familyId;
+        private List<Long> keywordIds;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/family/repository/FamilyKeywordRepository.java
+++ b/src/main/java/com/nuzzle/backend/family/repository/FamilyKeywordRepository.java
@@ -1,7 +1,12 @@
 package com.nuzzle.backend.family.repository;
 
+import com.nuzzle.backend.family.domain.Family;
 import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FamilyKeywordRepository extends JpaRepository<FamilyKeyword, Long> {
+    List<FamilyKeyword> findByFamily(Family family);
+
 }

--- a/src/main/java/com/nuzzle/backend/family/service/FamilyKeywordService.java
+++ b/src/main/java/com/nuzzle/backend/family/service/FamilyKeywordService.java
@@ -1,0 +1,11 @@
+package com.nuzzle.backend.family.service;
+
+import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
+
+import java.util.List;
+
+public interface FamilyKeywordService {
+
+    List<FamilyKeyword> getKeywordsByFamily(Long familyId);
+
+}

--- a/src/main/java/com/nuzzle/backend/family/service/impl/FamilyKeywordServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/family/service/impl/FamilyKeywordServiceImpl.java
@@ -1,0 +1,35 @@
+package com.nuzzle.backend.family.service.impl;
+
+import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
+import com.nuzzle.backend.family.repository.FamilyKeywordRepository;
+import com.nuzzle.backend.family.repository.FamilyRepository;
+import com.nuzzle.backend.family.service.FamilyKeywordService;
+import com.nuzzle.backend.keyword.domain.Keyword;
+import com.nuzzle.backend.keyword.repository.KeywordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FamilyKeywordServiceImpl implements FamilyKeywordService {
+
+    @Autowired
+    private FamilyKeywordRepository familyKeywordRepository;
+
+    @Autowired
+    private FamilyRepository familyRepository;
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+
+    @Override
+    public List<FamilyKeyword> getKeywordsByFamily(Long familyId) {
+        Family family = familyRepository.findById(familyId)
+                .orElseThrow(() -> new IllegalArgumentException("가족을 찾을 수 없습니다."));
+        return familyKeywordRepository.findByFamily(family);
+    }
+}


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [Nuzzle_BackEnd #11 ](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/11)
- Closes #11 

<br/>

## 📝 작업 내용
- 커밋명 삭제로 잘못 입력...했습니다
- 가족에 설정된 모든 키워드를 조회할 수 있는 API를 구현했습니다.
- 가족 ID를 사용하여 설정된 모든 키워드를 반환합니다.

<br/>

## 🔧 앞으로의 과제

- 키워드 조회 후 수정 및 삭제 기능을 추가할 예정입니다.
