### PR TITLE
✨[Feature] - 애착이 종류 랜덤 설정 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
+++ b/src/main/java/com/nuzzle/backend/family/controller/FamilyController.java
@@ -1,10 +1,12 @@
 package com.nuzzle.backend.family.controller;
 
 import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.dto.FamilyDTO;
 import com.nuzzle.backend.family.service.FamilyService;
 import com.nuzzle.backend.user.domain.User;
 import com.nuzzle.backend.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -98,5 +100,12 @@ public class FamilyController {
         response.put("invitation_code", invitation_code);
 
         return response;
+    }
+
+    // 랜덤 펫을 가족에 할당
+    @PatchMapping("/{familyId}/assign-random-pet")
+    public ResponseEntity<FamilyDTO> assignRandomPetToFamily(@PathVariable Long familyId) {
+        FamilyDTO familyDTO = family_service.assignRandomPetToFamily(familyId);
+        return ResponseEntity.ok(familyDTO);
     }
 }

--- a/src/main/java/com/nuzzle/backend/family/domain/Family.java
+++ b/src/main/java/com/nuzzle/backend/family/domain/Family.java
@@ -1,8 +1,11 @@
 package com.nuzzle.backend.family.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.nuzzle.backend.family.domain.mapping.FamilyKeyword;
 import com.nuzzle.backend.family.domain.mapping.FamilyQuestion;
 import com.nuzzle.backend.pet.domain.Pet;
+import com.nuzzle.backend.pet.domain.PetColor;
 import com.nuzzle.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -19,8 +22,9 @@ public class Family {
     @Column(name = "pet_name")
     private String petName;
 
+    @Enumerated(EnumType.STRING) // EnumType.STRING으로 지정
     @Column(name = "pet_color")
-    private String petColor;
+    private PetColor petColor;
 
     @Column(name = "family_status")
     private String familyStatus;
@@ -30,14 +34,18 @@ public class Family {
 
     @ManyToOne
     @JoinColumn(name = "pet_id")
+    @JsonBackReference
     private Pet pet;
 
     @OneToMany(mappedBy = "family")
+    @JsonManagedReference
     private List<FamilyQuestion> familyQuestions;
 
     @OneToMany(mappedBy = "family")
+    @JsonManagedReference
     private List<FamilyKeyword> familyKeywords;
 
     @OneToMany(mappedBy = "family")
+    @JsonManagedReference
     private List<User> users;
 }

--- a/src/main/java/com/nuzzle/backend/family/dto/FamilyDTO.java
+++ b/src/main/java/com/nuzzle/backend/family/dto/FamilyDTO.java
@@ -1,0 +1,36 @@
+package com.nuzzle.backend.family.dto;
+
+import com.nuzzle.backend.pet.domain.PetColor;
+import com.nuzzle.backend.pet.dto.PetDTO;
+import com.nuzzle.backend.user.dto.UserDTO;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class FamilyDTO {
+    private Long familyId;
+    private String petName;
+    private PetColor petColor;
+    private String familyStatus;
+    private String invitationCode;
+    private PetDTO pet;
+    private List<UserDTO> users;
+
+    // CreateFamilyRequest와 JoinFamilyRequest를 포함한 내부 클래스를 추가
+    @Data
+    public static class CreateFamilyRequest {
+        private Long userId;
+    }
+
+    @Data
+    public static class JoinFamilyRequest {
+        private Long userId;
+        private String invitationCode;
+    }
+
+    @Data
+    public static class LeaveFamilyRequest {
+        private Long userId;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/family/service/FamilyService.java
+++ b/src/main/java/com/nuzzle/backend/family/service/FamilyService.java
@@ -1,6 +1,7 @@
 package com.nuzzle.backend.family.service;
 
 import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.dto.FamilyDTO;
 import com.nuzzle.backend.user.domain.User;
 
 import java.util.List;
@@ -12,5 +13,8 @@ public interface FamilyService {
     Family getFamily(Long familyId); // 가족 정보를 가져오는 메서드
     List<User> getFamilyMembers(Long familyId); // 가족 구성원을 가져오는 메서드
     String getInvitationCode(Long familyId); // 가족 초대 코드를 가져오는 메서드
+
+    FamilyDTO assignRandomPetToFamily(Long familyId); // 랜덤 펫을 가족에 할당
+
 
 }

--- a/src/main/java/com/nuzzle/backend/family/service/impl/FamilyServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/family/service/impl/FamilyServiceImpl.java
@@ -1,9 +1,14 @@
 package com.nuzzle.backend.family.service.impl;
 
 import com.nuzzle.backend.family.domain.Family;
+import com.nuzzle.backend.family.dto.FamilyDTO;
 import com.nuzzle.backend.family.repository.FamilyRepository;
 import com.nuzzle.backend.family.service.FamilyService;
+import com.nuzzle.backend.pet.domain.Pet;
+import com.nuzzle.backend.pet.dto.PetDTO;
+import com.nuzzle.backend.pet.service.PetService;
 import com.nuzzle.backend.user.domain.User;
+import com.nuzzle.backend.user.dto.UserDTO;
 import com.nuzzle.backend.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,11 +17,15 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class FamilyServiceImpl implements FamilyService {
     @Autowired
     private FamilyRepository familyRepository;
+
+    @Autowired
+    private PetService petService;
 
     @Autowired
     private UserRepository userRepository;
@@ -89,5 +98,63 @@ public class FamilyServiceImpl implements FamilyService {
         // 가족 ID로 초대 코드 가져오기
         Family family = getFamily(familyId);
         return family.getInvitationCode();
+    }
+
+
+    @Transactional
+    @Override
+    public FamilyDTO assignRandomPetToFamily(Long familyId) {
+        Family family = familyRepository.findById(familyId)
+                .orElseThrow(() -> new IllegalArgumentException("가족을 찾을 수 없습니다."));
+
+        PetDTO randomPet = petService.getRandomPetType();
+        Pet pet = new Pet();
+        pet.setPetId(randomPet.getPetId());
+        pet.setPetType(randomPet.getPetType());
+        pet.setPetImg(randomPet.getPetImg());
+
+        family.setPet(pet);
+        familyRepository.save(family);
+
+        return convertToDTO(family);
+    }
+
+    //----------------------DTO 변환용 메소드 -------------------------------------
+    private FamilyDTO convertToDTO(Family family) {
+        FamilyDTO familyDTO = new FamilyDTO();
+        familyDTO.setFamilyId(family.getFamilyId());
+        familyDTO.setPetName(family.getPetName());
+        familyDTO.setPetColor(family.getPetColor());
+        familyDTO.setFamilyStatus(family.getFamilyStatus());
+        familyDTO.setInvitationCode(family.getInvitationCode());
+
+        if (family.getPet() != null) {
+            PetDTO petDTO = new PetDTO();
+            petDTO.setPetId(family.getPet().getPetId());
+            petDTO.setPetType(family.getPet().getPetType());
+            petDTO.setPetImg(family.getPet().getPetImg());
+            familyDTO.setPet(petDTO);
+        }
+
+        if (family.getUsers() != null) {
+            List<UserDTO> userDTOs = family.getUsers().stream().map(this::convertToUserDTO).collect(Collectors.toList());
+            familyDTO.setUsers(userDTOs);
+        }
+
+        return familyDTO;
+    }
+
+    private UserDTO convertToUserDTO(User user) {
+        UserDTO userDTO = new UserDTO();
+        userDTO.setUserId(user.getUserId());
+        userDTO.setUserName(user.getUserName());
+        userDTO.setGender(user.getGender());
+        userDTO.setSerialId(user.getSerialId());
+        userDTO.setPassword(user.getPassword());
+        userDTO.setRole(user.getRole());
+        userDTO.setBirthDate(user.getBirthDate().toString());
+
+        // 사용자 DTO는 Family를 포함하지 않음
+        return userDTO;
     }
 }

--- a/src/main/java/com/nuzzle/backend/pet/domain/PetColor.java
+++ b/src/main/java/com/nuzzle/backend/pet/domain/PetColor.java
@@ -1,0 +1,9 @@
+package com.nuzzle.backend.pet.domain;
+
+public enum PetColor {
+    BLACK,
+    BROWN,
+    WHITE,
+    GOLDEN,
+    GRAY
+}

--- a/src/main/java/com/nuzzle/backend/pet/dto/PetDTO.java
+++ b/src/main/java/com/nuzzle/backend/pet/dto/PetDTO.java
@@ -1,0 +1,10 @@
+package com.nuzzle.backend.pet.dto;
+
+import lombok.Data;
+
+@Data
+public class PetDTO {
+    private Long petId;
+    private String petType;
+    private String petImg;
+}

--- a/src/main/java/com/nuzzle/backend/pet/service/PetService.java
+++ b/src/main/java/com/nuzzle/backend/pet/service/PetService.java
@@ -1,0 +1,7 @@
+package com.nuzzle.backend.pet.service;
+
+import com.nuzzle.backend.pet.dto.PetDTO;
+
+public interface PetService {
+    PetDTO getRandomPetType(); // 랜덤으로 하나의 펫을 반환하는 메서드
+}

--- a/src/main/java/com/nuzzle/backend/pet/service/impl/PetServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/pet/service/impl/PetServiceImpl.java
@@ -1,0 +1,37 @@
+package com.nuzzle.backend.pet.service.impl;
+
+import com.nuzzle.backend.pet.domain.Pet;
+import com.nuzzle.backend.pet.dto.PetDTO;
+import com.nuzzle.backend.pet.repository.PetRepository;
+import com.nuzzle.backend.pet.service.PetService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Random;
+
+@Service
+public class PetServiceImpl implements PetService {
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Override
+    public PetDTO getRandomPetType() {
+        List<Pet> allPets = petRepository.findAll();
+        if (allPets.isEmpty()) {
+            throw new IllegalStateException("No pets available.");
+        }
+        Random random = new Random();
+        Pet randomPet = allPets.get(random.nextInt(allPets.size()));
+        return convertToDTO(randomPet);
+    }
+
+    private PetDTO convertToDTO(Pet pet) {
+        PetDTO petDTO = new PetDTO();
+        petDTO.setPetId(pet.getPetId());
+        petDTO.setPetType(pet.getPetType());
+        petDTO.setPetImg(pet.getPetImg());
+        return petDTO;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/user/dto/UserDTO.java
+++ b/src/main/java/com/nuzzle/backend/user/dto/UserDTO.java
@@ -1,0 +1,16 @@
+package com.nuzzle.backend.user.dto;
+
+import com.nuzzle.backend.family.dto.FamilyDTO;
+import lombok.Data;
+
+@Data
+public class UserDTO {
+    private Long userId;
+    private String userName;
+    private String gender;
+    private String serialId;
+    private String password;
+    private String role;
+    private String birthDate;
+    private FamilyDTO family;
+}


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [Nuzzle_BackEnd #16 ](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/16)
- Closes #16 

<br/>

## 📝 작업 내용

- 애착이의 종류를 랜덤으로 설정할 수 있는 API를 구현했습니다.
- 설정된 종류는 가족의 애착이로 등록되며, 랜덤으로 종류가 선택됩니다.

<br/>

## 🔧 앞으로의 과제

- 랜덤으로 설정된 애착이를 저장하고, 이후에 조회할 수 있는 기능을 추가할 예정입니다.
