### PR TITLE
✨[Feature] - 사진에 이모지 등록 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/emoji/controller/EmojiController.java
+++ b/src/main/java/com/nuzzle/backend/emoji/controller/EmojiController.java
@@ -1,0 +1,43 @@
+package com.nuzzle.backend.emoji.controller;
+
+import com.nuzzle.backend.emoji.dto.AddEmojiRequest;
+
+import com.nuzzle.backend.emoji.dto.PictureEmojiResponseDTO;
+import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+import com.nuzzle.backend.picture.service.PictureEmojiService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/emoji")
+public class EmojiController {
+
+
+
+    @Autowired
+    private PictureEmojiService pictureEmojiService;
+
+
+
+    @PostMapping("/pictures/{pictureId}/emojis")
+    public ResponseEntity<PictureEmojiResponseDTO> addEmojiToPicture(@PathVariable Long pictureId,
+                                                                     @RequestBody AddEmojiRequest request) {
+        PictureEmoji pictureEmoji = pictureEmojiService.addEmojiToPicture(pictureId, request.getUserId(), request.getEmojiId());
+
+        PictureEmojiResponseDTO responseDTO = new PictureEmojiResponseDTO(
+                pictureEmoji.getPictureEmojiId(),
+                pictureEmoji.getEmoji().getEmojiId(),
+                pictureEmoji.getEmoji().getEmojiImg(),
+                pictureEmoji.getPicture().getPictureId(),
+                pictureEmoji.getPicture().getPictureURL(),
+                pictureEmoji.getUser().getUserId(),
+                pictureEmoji.getUser().getUserName()
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDTO);
+    }
+
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/AddEmojiRequest.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/AddEmojiRequest.java
@@ -1,0 +1,9 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class AddEmojiRequest {
+    private Long userId;
+    private Long emojiId;
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/EmojiDto.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/EmojiDto.java
@@ -1,0 +1,14 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class EmojiDto {
+    private Long emojiId;
+    private String emojiImg;
+
+    public EmojiDto(Long emojiId, String emojiImg) {
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/EmojiUserDto.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/EmojiUserDto.java
@@ -1,0 +1,18 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class EmojiUserDto {
+    private Long userId;
+    private String userName;
+    private Long emojiId;
+    private String emojiImg;
+
+    public EmojiUserDto(Long userId, String userName, Long emojiId, String emojiImg) {
+        this.userId = userId;
+        this.userName = userName;
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/PictureEmojiResponseDTO.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/PictureEmojiResponseDTO.java
@@ -1,0 +1,24 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class PictureEmojiResponseDTO {
+    private Long pictureEmojiId;
+    private Long emojiId;
+    private String emojiImg;
+    private Long pictureId;
+    private String pictureURL;
+    private Long userId;
+    private String userName;
+
+    public PictureEmojiResponseDTO(Long pictureEmojiId, Long emojiId, String emojiImg, Long pictureId, String pictureURL, Long userId, String userName) {
+        this.pictureEmojiId = pictureEmojiId;
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+        this.pictureId = pictureId;
+        this.pictureURL = pictureURL;
+        this.userId = userId;
+        this.userName = userName;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/picture/domain/mapping/PictureEmoji.java
+++ b/src/main/java/com/nuzzle/backend/picture/domain/mapping/PictureEmoji.java
@@ -2,6 +2,7 @@ package com.nuzzle.backend.picture.domain.mapping;
 
 import com.nuzzle.backend.emoji.domain.Emoji;
 import com.nuzzle.backend.picture.domain.Picture;
+import com.nuzzle.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -20,4 +21,8 @@ public class PictureEmoji {
     @ManyToOne
     @JoinColumn(name = "picture_id")
     private Picture picture;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;  // 이모티콘을 등록한 유저
 }

--- a/src/main/java/com/nuzzle/backend/picture/service/PictureEmojiService.java
+++ b/src/main/java/com/nuzzle/backend/picture/service/PictureEmojiService.java
@@ -1,0 +1,9 @@
+package com.nuzzle.backend.picture.service;
+
+import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+
+import java.util.List;
+
+public interface PictureEmojiService {
+    PictureEmoji addEmojiToPicture(Long pictureId, Long userId, Long emojiId);
+}

--- a/src/main/java/com/nuzzle/backend/picture/service/PictureService.java
+++ b/src/main/java/com/nuzzle/backend/picture/service/PictureService.java
@@ -1,0 +1,7 @@
+package com.nuzzle.backend.picture.service;
+
+import com.nuzzle.backend.picture.domain.Picture;
+
+public interface PictureService {
+    Picture findPictureById(Long pictureId);
+}

--- a/src/main/java/com/nuzzle/backend/picture/service/impl/PictureEmojiServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/picture/service/impl/PictureEmojiServiceImpl.java
@@ -1,0 +1,54 @@
+package com.nuzzle.backend.picture.service.impl;
+
+import com.nuzzle.backend.emoji.domain.Emoji;
+import com.nuzzle.backend.emoji.repository.EmojiRepository;
+import com.nuzzle.backend.picture.domain.Picture;
+import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+import com.nuzzle.backend.picture.repository.PictureEmojiRepository;
+import com.nuzzle.backend.picture.repository.PictureRepository;
+import com.nuzzle.backend.picture.service.PictureEmojiService;
+import com.nuzzle.backend.user.domain.User;
+import com.nuzzle.backend.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class PictureEmojiServiceImpl implements PictureEmojiService {
+
+    @Autowired
+    private PictureRepository pictureRepository;
+
+    @Autowired
+    private PictureEmojiRepository pictureEmojiRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EmojiRepository emojiRepository;
+
+    @Override
+    @Transactional
+    public PictureEmoji addEmojiToPicture(Long pictureId, Long userId, Long emojiId) {
+        Picture picture = pictureRepository.findById(pictureId)
+                .orElseThrow(() -> new IllegalArgumentException("Picture not found"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Emoji emoji = emojiRepository.findById(emojiId)
+                .orElseThrow(() -> new IllegalArgumentException("Emoji not found"));
+
+        PictureEmoji pictureEmoji = new PictureEmoji();
+        pictureEmoji.setPicture(picture);
+        pictureEmoji.setUser(user);  // 이모티콘을 등록한 유저 설정
+        pictureEmoji.setEmoji(emoji);
+
+        return pictureEmojiRepository.save(pictureEmoji);
+    }
+
+
+}

--- a/src/main/java/com/nuzzle/backend/picture/service/impl/PictureServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/picture/service/impl/PictureServiceImpl.java
@@ -1,0 +1,24 @@
+package com.nuzzle.backend.picture.service.impl;
+
+import com.nuzzle.backend.picture.domain.Picture;
+import com.nuzzle.backend.picture.repository.PictureRepository;
+import com.nuzzle.backend.picture.service.PictureService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PictureServiceImpl implements PictureService {
+
+    private final PictureRepository pictureRepository;
+
+    @Autowired
+    public PictureServiceImpl(PictureRepository pictureRepository) {
+        this.pictureRepository = pictureRepository;
+    }
+
+    @Override
+    public Picture findPictureById(Long pictureId) {
+        return pictureRepository.findById(pictureId)
+                .orElseThrow(() -> new RuntimeException("Picture not found"));
+    }
+}


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [Nuzzle_BackEnd #17 ](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/17)
- Closes #17 

<br/>

## 📝 작업 내용

- 사용자가 사진에 이모지를 등록할 수 있는 API를 구현했습니다.
- 사진 ID와 이모지 정보를 받아 저장하는 기능을 추가했습니다.

<br/>

## 🔧 앞으로의 과제

- 사진에 이미 등록된 이모지가 있는 경우 중복 등록되지 않도록 하는 기능을 추가할 예정입니다.
