### PR TITLE
✨[Feature] - 사진에 등록된 이모지 조회 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/emoji/controller/EmojiController.java
+++ b/src/main/java/com/nuzzle/backend/emoji/controller/EmojiController.java
@@ -1,0 +1,35 @@
+package com.nuzzle.backend.emoji.controller;
+
+
+import com.nuzzle.backend.emoji.dto.EmojiUserDto;
+import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+import com.nuzzle.backend.picture.service.PictureEmojiService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/emoji")
+public class EmojiController {
+
+
+    @Autowired
+    private PictureEmojiService pictureEmojiService;
+
+    @GetMapping("/pictures/{pictureId}/emojis")
+    public ResponseEntity<List<EmojiUserDto>> getEmojisByPicture(@PathVariable Long pictureId) {
+        List<PictureEmoji> pictureEmojis = pictureEmojiService.getEmojisByPictureId(pictureId);
+
+        List<EmojiUserDto> response = pictureEmojis.stream().map(pe -> new EmojiUserDto(
+                pe.getUser().getUserId(),
+                pe.getUser().getUserName(),
+                pe.getEmoji().getEmojiId(),
+                pe.getEmoji().getEmojiImg()
+        )).collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/AddEmojiRequest.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/AddEmojiRequest.java
@@ -1,0 +1,9 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class AddEmojiRequest {
+    private Long userId;
+    private Long emojiId;
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/EmojiDto.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/EmojiDto.java
@@ -1,0 +1,14 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class EmojiDto {
+    private Long emojiId;
+    private String emojiImg;
+
+    public EmojiDto(Long emojiId, String emojiImg) {
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/EmojiUserDto.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/EmojiUserDto.java
@@ -1,0 +1,18 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class EmojiUserDto {
+    private Long userId;
+    private String userName;
+    private Long emojiId;
+    private String emojiImg;
+
+    public EmojiUserDto(Long userId, String userName, Long emojiId, String emojiImg) {
+        this.userId = userId;
+        this.userName = userName;
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/PictureEmojiResponseDTO.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/PictureEmojiResponseDTO.java
@@ -1,0 +1,24 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class PictureEmojiResponseDTO {
+    private Long pictureEmojiId;
+    private Long emojiId;
+    private String emojiImg;
+    private Long pictureId;
+    private String pictureURL;
+    private Long userId;
+    private String userName;
+
+    public PictureEmojiResponseDTO(Long pictureEmojiId, Long emojiId, String emojiImg, Long pictureId, String pictureURL, Long userId, String userName) {
+        this.pictureEmojiId = pictureEmojiId;
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+        this.pictureId = pictureId;
+        this.pictureURL = pictureURL;
+        this.userId = userId;
+        this.userName = userName;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/picture/domain/mapping/PictureEmoji.java
+++ b/src/main/java/com/nuzzle/backend/picture/domain/mapping/PictureEmoji.java
@@ -2,6 +2,7 @@ package com.nuzzle.backend.picture.domain.mapping;
 
 import com.nuzzle.backend.emoji.domain.Emoji;
 import com.nuzzle.backend.picture.domain.Picture;
+import com.nuzzle.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -20,4 +21,8 @@ public class PictureEmoji {
     @ManyToOne
     @JoinColumn(name = "picture_id")
     private Picture picture;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;  // 이모티콘을 등록한 유저
 }

--- a/src/main/java/com/nuzzle/backend/picture/repository/PictureEmojiRepository.java
+++ b/src/main/java/com/nuzzle/backend/picture/repository/PictureEmojiRepository.java
@@ -1,7 +1,13 @@
 package com.nuzzle.backend.picture.repository;
 
+import com.nuzzle.backend.picture.domain.Picture;
 import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+import com.nuzzle.backend.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PictureEmojiRepository extends JpaRepository<PictureEmoji, Long> {
+    List<PictureEmoji> findByPicture(Picture picture);  // Picture 객체를 기반으로 이모티콘 정보 조회
+
 }

--- a/src/main/java/com/nuzzle/backend/picture/service/PictureEmojiService.java
+++ b/src/main/java/com/nuzzle/backend/picture/service/PictureEmojiService.java
@@ -1,0 +1,10 @@
+package com.nuzzle.backend.picture.service;
+
+import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+
+import java.util.List;
+
+public interface PictureEmojiService {
+    PictureEmoji addEmojiToPicture(Long pictureId, Long userId, Long emojiId);
+    List<PictureEmoji> getEmojisByPictureId(Long pictureId);
+}

--- a/src/main/java/com/nuzzle/backend/picture/service/impl/PictureEmojiServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/picture/service/impl/PictureEmojiServiceImpl.java
@@ -1,0 +1,60 @@
+package com.nuzzle.backend.picture.service.impl;
+
+import com.nuzzle.backend.emoji.domain.Emoji;
+import com.nuzzle.backend.emoji.repository.EmojiRepository;
+import com.nuzzle.backend.picture.domain.Picture;
+import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+import com.nuzzle.backend.picture.repository.PictureEmojiRepository;
+import com.nuzzle.backend.picture.repository.PictureRepository;
+import com.nuzzle.backend.picture.service.PictureEmojiService;
+import com.nuzzle.backend.user.domain.User;
+import com.nuzzle.backend.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class PictureEmojiServiceImpl implements PictureEmojiService {
+
+    @Autowired
+    private PictureRepository pictureRepository;
+
+    @Autowired
+    private PictureEmojiRepository pictureEmojiRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EmojiRepository emojiRepository;
+
+    @Override
+    @Transactional
+    public PictureEmoji addEmojiToPicture(Long pictureId, Long userId, Long emojiId) {
+        Picture picture = pictureRepository.findById(pictureId)
+                .orElseThrow(() -> new IllegalArgumentException("Picture not found"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Emoji emoji = emojiRepository.findById(emojiId)
+                .orElseThrow(() -> new IllegalArgumentException("Emoji not found"));
+
+        PictureEmoji pictureEmoji = new PictureEmoji();
+        pictureEmoji.setPicture(picture);
+        pictureEmoji.setUser(user);  // 이모티콘을 등록한 유저 설정
+        pictureEmoji.setEmoji(emoji);
+
+        return pictureEmojiRepository.save(pictureEmoji);
+    }
+
+    @Override
+    public List<PictureEmoji> getEmojisByPictureId(Long pictureId) {
+        Picture picture = pictureRepository.findById(pictureId)
+                .orElseThrow(() -> new IllegalArgumentException("Picture not found"));
+
+        return pictureEmojiRepository.findByPicture(picture);  // Picture 객체로 조회
+    }
+}


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [Nuzzle_BackEnd #18 ](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/18)
- Closes #18 

<br/>

## 📝 작업 내용

- 특정 사진에 등록된 모든 이모지를 조회할 수 있는 API를 구현했습니다.
- 사진 ID를 통해 이모지를 조회하고, 해당 이모지를 등록한 유저 정보를 반환합니다.

<br/>

## 🔧 앞으로의 과제

- 조회된 이모지를 사용하여 UI에 표시하는 작업을 진행할 예정입니다.
