### PR TITLE
✨[Feature] - 서버의 전체 이모지 가져오기 API

### DIFF
--- a/src/main/java/com/nuzzle/backend/emoji/controller/EmojiController.java
+++ b/src/main/java/com/nuzzle/backend/emoji/controller/EmojiController.java
@@ -1,0 +1,26 @@
+package com.nuzzle.backend.emoji.controller;
+
+import com.nuzzle.backend.emoji.dto.EmojiDto;
+import com.nuzzle.backend.emoji.service.EmojiService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/emoji")
+public class EmojiController {
+
+    @Autowired
+    private EmojiService emojiService;
+
+
+
+    @GetMapping("/all")
+    public ResponseEntity<List<EmojiDto>> getAllEmojis() {
+        List<EmojiDto> emojis = emojiService.findAllEmojis();
+        return ResponseEntity.ok(emojis);
+    }
+
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/AddEmojiRequest.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/AddEmojiRequest.java
@@ -1,0 +1,9 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class AddEmojiRequest {
+    private Long userId;
+    private Long emojiId;
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/EmojiDto.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/EmojiDto.java
@@ -1,0 +1,14 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class EmojiDto {
+    private Long emojiId;
+    private String emojiImg;
+
+    public EmojiDto(Long emojiId, String emojiImg) {
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/EmojiUserDto.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/EmojiUserDto.java
@@ -1,0 +1,18 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class EmojiUserDto {
+    private Long userId;
+    private String userName;
+    private Long emojiId;
+    private String emojiImg;
+
+    public EmojiUserDto(Long userId, String userName, Long emojiId, String emojiImg) {
+        this.userId = userId;
+        this.userName = userName;
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/dto/PictureEmojiResponseDTO.java
+++ b/src/main/java/com/nuzzle/backend/emoji/dto/PictureEmojiResponseDTO.java
@@ -1,0 +1,24 @@
+package com.nuzzle.backend.emoji.dto;
+
+import lombok.Data;
+
+@Data
+public class PictureEmojiResponseDTO {
+    private Long pictureEmojiId;
+    private Long emojiId;
+    private String emojiImg;
+    private Long pictureId;
+    private String pictureURL;
+    private Long userId;
+    private String userName;
+
+    public PictureEmojiResponseDTO(Long pictureEmojiId, Long emojiId, String emojiImg, Long pictureId, String pictureURL, Long userId, String userName) {
+        this.pictureEmojiId = pictureEmojiId;
+        this.emojiId = emojiId;
+        this.emojiImg = emojiImg;
+        this.pictureId = pictureId;
+        this.pictureURL = pictureURL;
+        this.userId = userId;
+        this.userName = userName;
+    }
+}

--- a/src/main/java/com/nuzzle/backend/emoji/service/EmojiService.java
+++ b/src/main/java/com/nuzzle/backend/emoji/service/EmojiService.java
@@ -1,0 +1,11 @@
+package com.nuzzle.backend.emoji.service;
+
+import com.nuzzle.backend.emoji.domain.Emoji;
+import com.nuzzle.backend.emoji.dto.EmojiDto;
+
+import java.util.List;
+public interface EmojiService {
+    List<EmojiDto> findRecentEmojisByUser(Long userId, int count);
+    List<EmojiDto> findAllEmojis();
+    Emoji saveEmoji(Emoji emoji);
+}

--- a/src/main/java/com/nuzzle/backend/emoji/service/impl/EmojiServiceImpl.java
+++ b/src/main/java/com/nuzzle/backend/emoji/service/impl/EmojiServiceImpl.java
@@ -1,0 +1,73 @@
+package com.nuzzle.backend.emoji.service.impl;
+
+import com.nuzzle.backend.emoji.domain.Emoji;
+import com.nuzzle.backend.emoji.dto.EmojiDto;
+import com.nuzzle.backend.emoji.repository.EmojiRepository;
+import com.nuzzle.backend.emoji.service.EmojiService;
+import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
+import com.nuzzle.backend.picture.repository.PictureEmojiRepository;
+import com.nuzzle.backend.user.domain.User;
+import com.nuzzle.backend.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+public class EmojiServiceImpl implements EmojiService {
+
+    @Autowired
+    private EmojiRepository emojiRepository;
+
+    @Autowired
+    private PictureEmojiRepository pictureEmojiRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public List<EmojiDto> findAllEmojis() {
+        return emojiRepository.findAll().stream()
+                .map(emoji -> new EmojiDto(emoji.getEmojiId(), emoji.getEmojiImg()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<EmojiDto> findRecentEmojisByUser(Long userId, int count) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("User not found"));
+        List<PictureEmoji> recentPictureEmojis = pictureEmojiRepository.findTop5ByUserOrderByPictureEmojiIdDesc(user);
+
+        // 중복되지 않은 최근 사용 이모티콘 목록 추출
+        Set<Long> uniqueEmojiIds = new HashSet<>();
+        List<EmojiDto> recentEmojis = recentPictureEmojis.stream()
+                .filter(pe -> uniqueEmojiIds.add(pe.getEmoji().getEmojiId())) // 중복 제거
+                .map(pe -> new EmojiDto(pe.getEmoji().getEmojiId(), pe.getEmoji().getEmojiImg()))
+                .collect(Collectors.toList());
+
+        // 만약 중복 제거 후 5개 미만일 경우 기본값 이모티콘 추가
+        if (recentEmojis.size() < count) {
+            List<Emoji> defaultEmojis = emojiRepository.findAllById(Arrays.asList(1L, 2L, 3L, 4L, 5L));
+            Set<Long> existingEmojiIds = recentEmojis.stream().map(EmojiDto::getEmojiId).collect(Collectors.toSet());
+
+            for (Emoji defaultEmoji : defaultEmojis) {
+                if (recentEmojis.size() >= count) {
+                    break;
+                }
+                if (!existingEmojiIds.contains(defaultEmoji.getEmojiId())) {
+                    recentEmojis.add(new EmojiDto(defaultEmoji.getEmojiId(), defaultEmoji.getEmojiImg()));
+                }
+            }
+        }
+
+        return recentEmojis;
+    }
+
+    @Override
+    public Emoji saveEmoji(Emoji emoji) {
+        return emojiRepository.save(emoji);
+    }
+}

--- a/src/main/java/com/nuzzle/backend/picture/domain/Picture.java
+++ b/src/main/java/com/nuzzle/backend/picture/domain/Picture.java
@@ -4,6 +4,8 @@ import com.nuzzle.backend.picture.domain.mapping.PictureEmoji;
 import com.nuzzle.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Data;
+
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -27,4 +29,6 @@ public class Picture {
 
     @Column(name = "upload_date")
     private LocalDateTime uploadDate;
+
+
 }


### PR DESCRIPTION
## 🔎 관련 이슈 링크

- [Nuzzle_BackEnd #19 ](https://github.com/NuzzleTeam/Nuzzle_BackEnd/issues/19)
- Closes #19 

<br/>

## 📝 작업 내용

- 서버에 저장된 모든 이모지를 조회할 수 있는 API를 구현했습니다.
- 이모지는 배열 형태로 반환됩니다.

<br/>

## 🔧 앞으로의 과제

- 전체 이모지 중 유저가 선호하는 이모지를 추천하는 기능을 추가할 예정입니다.
